### PR TITLE
Dont store locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mozilla-payments-config",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Payments Config",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/payments_config/utils.py
+++ b/payments_config/utils.py
@@ -13,6 +13,7 @@ ready_locales = [
     'en'
 ]
 
+
 class wrapper(object):
     """
     Wrap translated strings so they can be identified by the encoder.


### PR DESCRIPTION
- this was making tests in solitude hard because it was hard to get at products and sellers without manipulating the sellers and products in the shared library
- this creates a populate command which returns the stores and keeps the concerns seperate
- related to mozilla/solitude#537 which was getting to rely on the data in payments-config too much
